### PR TITLE
FIX flaky segmentation fault case in CLD2

### DIFF
--- a/cld2/src/main/java/com/idibon/ml/cld2/CLD2.java
+++ b/cld2/src/main/java/com/idibon/ml/cld2/CLD2.java
@@ -34,9 +34,16 @@ public final class CLD2 {
      */
     public static LangID detect(String content, DocumentMode mode) {
         mustBeInitialized();
+
         // CLD2 only operates on UTF-8 bytes. convert to UTF-8 before calling
-        int cld = cld2_Detect(content.getBytes(UTF_8),
-                              mode == DocumentMode.PlainText);
+        byte[] contentBytes = content.getBytes(UTF_8);
+
+        // Add null terminator character, so we don't get segmentation fault inside of CLD2
+        byte[] nullTerminatedContentBytes = new byte[contentBytes.length + 1];
+        System.arraycopy(contentBytes, 0, nullTerminatedContentBytes, 0, contentBytes.length);
+        nullTerminatedContentBytes[contentBytes.length] = 0;
+
+        int cld = cld2_Detect(nullTerminatedContentBytes, mode == DocumentMode.PlainText);
         return LangID.of(Math.abs(cld));
     }
 


### PR DESCRIPTION
We catch the next error using `CLD2.detect` on large datasets:
```
A fatal error has been detected by the Java Runtime Environment:
SIGSEGV (0xb) at pc=0x00007f744dc563d3, pid=7, tid=0x00007f749f8f8700
JRE version: Java(TM) SE Runtime Environment (8.0_161-b12) (build 1.8.0_161-b12)
Java VM: Java HotSpot(TM) 64-Bit Server VM (25.161-b12 mixed mode linux-amd64 )
Problematic frame:
C  [jni-linux.amd64.so+0x2d3d3]
 CLD2::UTF8GenericPropertyTwoByte(CLD2::UTF8StateMachineObj_2 const*, unsigned char const**, int*)+0x103
```

`gdb` shows that we catch some additional noise together with a string passed from Java:
```
    buffer=buffer@entry=0x7f940805efc0 "콘 피자랑 큐브 피자.... 대단하시네요... 생각도 못해봤는데... 많이 배우고 갑니다 ㅇㅅㅇb5\002",
```
Note `5\002` sequence in the end.
My best guess - it's caused by missing null terminator.
Local testing proves this theory.
I haven't added this check to `CLD2Test`, because tests aren't deterministic.